### PR TITLE
Fix typo in SendPasswordResetEmail function

### DIFF
--- a/internal/handlers/postforgotpassword.go
+++ b/internal/handlers/postforgotpassword.go
@@ -49,8 +49,8 @@ func (h *PostForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 
 	// Send the email TODO: Implement
-        resetLink := fmt.Sprintf("%s?token=%s", linkTemplate, token)
-        err = h.emailService.SendPasswordResetEmail(user.Email, resetLink)
+	resetLink := fmt.Sprintf("%s?token=%s", linkTemplate, token)
+	err = h.emailService.SendPasswordResetEmail(user.Email, resetLink)
 	if err != nil {
 		http.Error(w, "Failed to send email", http.StatusInternalServerError)
 		return

--- a/internal/handlers/postforgotpassword.go
+++ b/internal/handlers/postforgotpassword.go
@@ -49,8 +49,8 @@ func (h *PostForgotPasswordHandler) ServeHTTP(w http.ResponseWriter, r *http.Req
 	}
 
 	// Send the email TODO: Implement
-	resetLink := fmt.Sprintf("%s?token=%s", linkTemplate, token)
-	err = h.emailService.SendPassswordResetEmail(user.Email, resetLink)
+        resetLink := fmt.Sprintf("%s?token=%s", linkTemplate, token)
+        err = h.emailService.SendPasswordResetEmail(user.Email, resetLink)
 	if err != nil {
 		http.Error(w, "Failed to send email", http.StatusInternalServerError)
 		return

--- a/internal/models/email.go
+++ b/internal/models/email.go
@@ -13,7 +13,7 @@ type EmailService struct {
 	From     string
 }
 
-func (e *EmailService) SendPassswordResetEmail(toEmail string, resetLink string) error {
+func (e *EmailService) SendPasswordResetEmail(toEmail string, resetLink string) error {
 	subject := "Reset Your Password"
 	body := fmt.Sprintf("Click the link to reset your password:\n\n%s", resetLink)
 


### PR DESCRIPTION
## Summary
- rename EmailService.SendPassswordResetEmail to SendPasswordResetEmail
- update PostForgotPassword handler to call the new method

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68955a0a463c832cb21dcd8517b7ef24