### PR TITLE
Use email lookup for login handler

### DIFF
--- a/internal/database/user_test.go
+++ b/internal/database/user_test.go
@@ -1,0 +1,55 @@
+package database
+
+import (
+	"database/sql"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	m "github.com/skywall34/trip-tracker/internal/models"
+)
+
+func setupTestDB(t *testing.T) *sql.DB {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	createUsersTable := `
+    CREATE TABLE users (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        username TEXT,
+        password TEXT,
+        first_name TEXT,
+        last_name TEXT,
+        email TEXT UNIQUE NOT NULL
+    );`
+	if _, err := db.Exec(createUsersTable); err != nil {
+		t.Fatalf("failed to create users table: %v", err)
+	}
+	return db
+}
+
+func TestGetUserGivenEmail(t *testing.T) {
+	sqlDB := setupTestDB(t)
+	store := NewUserStore(NewUserStoreParams{DB: sqlDB})
+
+	user := m.User{
+		Username:  "testuser",
+		Password:  "secret",
+		FirstName: "Test",
+		LastName:  "User",
+		Email:     "test@example.com",
+	}
+	if _, err := store.CreateUser(user); err != nil {
+		t.Fatalf("failed to create user: %v", err)
+	}
+
+	got, err := store.GetUserGivenEmail("test@example.com")
+	if err != nil {
+		t.Fatalf("GetUserGivenEmail returned error: %v", err)
+	}
+	if got.Email != user.Email || got.Username != user.Username {
+		t.Fatalf("expected user %v, got %v", user, got)
+	}
+}

--- a/internal/handlers/postlogin.go
+++ b/internal/handlers/postlogin.go
@@ -13,28 +13,28 @@ import (
 )
 
 type PostLoginHandler struct {
-	userStore *db.UserStore
+	userStore    *db.UserStore
 	sessionStore *db.SessionStore
 }
 
 type PostLoginHandlerParams struct {
-	UserStore *db.UserStore
+	UserStore    *db.UserStore
 	SessionStore *db.SessionStore
 }
 
 func NewPostLoginHandler(params PostLoginHandlerParams) *PostLoginHandler {
 	return &PostLoginHandler{
-		userStore: params.UserStore,
+		userStore:    params.UserStore,
 		sessionStore: params.SessionStore,
 	}
 }
 
 func comparePasswords(password, hashedPassword string) (bool, error) {
-    err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
-    if err != nil {
-        return false, err
-    }
-    return true, nil
+	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (h *PostLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -48,7 +48,7 @@ func (h *PostLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	password := r.FormValue("password")
 
 	// TODO: Proper authentication logic here
-	user, err := h.userStore.GetUser(email)
+	user, err := h.userStore.GetUserGivenEmail(email)
 	if err != nil {
 		w.WriteHeader(http.StatusUnauthorized)
 		c := templates.LoginError()
@@ -80,7 +80,7 @@ func (h *PostLoginHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Name:     "session_id",
 		Value:    sessionID,
 		Path:     "/",
-		HttpOnly: true, // Prevents JavaScript access (security best practice)
+		HttpOnly: true,  // Prevents JavaScript access (security best practice)
 		MaxAge:   86400, // 1 day in seconds
 	})
 


### PR DESCRIPTION
## Summary
- Switch login handler to retrieve users via `GetUserGivenEmail`
- Add unit test to confirm `GetUserGivenEmail` returns the correct user

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68955a9489b4832c8a51fd2dfa187c21