### PR TITLE
test: add parseLocalToUTC coverage

### DIFF
--- a/internal/handlers/edittrip.go
+++ b/internal/handlers/edittrip.go
@@ -8,7 +8,6 @@ import (
 	m "github.com/skywall34/trip-tracker/internal/middleware"
 )
 
-
 type EditTripHandler struct {
 	tripStore *db.TripStore
 }
@@ -17,7 +16,7 @@ type EditTripHandlerParams struct {
 	TripStore *db.TripStore
 }
 
-func NewEditTripHandler(params EditTripHandlerParams) (*EditTripHandler) {
+func NewEditTripHandler(params EditTripHandlerParams) *EditTripHandler {
 	return &EditTripHandler{
 		tripStore: params.TripStore,
 	}
@@ -58,7 +57,7 @@ func (t *EditTripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if departureTimeString := r.FormValue("departuretime"); departureTimeString != "" {
 		timezone := r.FormValue("timezone")
-		parsedDepartureTime, err := parseLocalToUTC(departureTimeString, existingTrip.Departure, timezone)
+		parsedDepartureTime, err := ParseLocalToUTC(departureTimeString, existingTrip.Departure, timezone)
 		if err != nil {
 			http.Error(w, "Error parsing departure time", http.StatusBadRequest)
 			return
@@ -68,7 +67,7 @@ func (t *EditTripHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	if arrivalTimeString := r.FormValue("arrivaltime"); arrivalTimeString != "" {
 		timezone := r.FormValue("timezone")
-		parsedArrivalTime, err := parseLocalToUTC(arrivalTimeString, existingTrip.Arrival, timezone)
+		parsedArrivalTime, err := ParseLocalToUTC(arrivalTimeString, existingTrip.Arrival, timezone)
 		if err != nil {
 			http.Error(w, "Error parsing arrival time", http.StatusBadRequest)
 			return

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,21 @@
+# Testing
+
+This project uses Go's built-in testing tools. All test files reside in the `testing` directory.
+
+## Run all tests
+
+From the repository root, execute:
+
+```bash
+go test ./...
+```
+
+## Run specific tests
+
+To run tests for a single package with verbose output:
+
+```bash
+go test -v ./testing -run TestParseLocalToUTC
+```
+
+Set `-count=1` to avoid cached results when re-running tests.

--- a/testing/posttrip_test.go
+++ b/testing/posttrip_test.go
@@ -1,0 +1,41 @@
+package tests
+
+import (
+	"testing"
+	"time"
+
+	"github.com/skywall34/trip-tracker/internal/handlers"
+	"github.com/skywall34/trip-tracker/internal/models"
+)
+
+func TestParseLocalToUTC(t *testing.T) {
+	orig := models.AirportTimezoneLookup
+	models.AirportTimezoneLookup = map[string]string{"JFK": "America/New_York"}
+	t.Cleanup(func() { models.AirportTimezoneLookup = orig })
+
+	got, err := handlers.ParseLocalToUTC("2023-01-02T15:04", "JFK", "America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("ParseLocalToUTC returned error: %v", err)
+	}
+
+	expected := time.Date(2023, time.January, 2, 20, 4, 0, 0, time.UTC)
+	if !got.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}
+
+func TestParseLocalToUTCFallbackToProvidedTimezone(t *testing.T) {
+	orig := models.AirportTimezoneLookup
+	models.AirportTimezoneLookup = map[string]string{}
+	t.Cleanup(func() { models.AirportTimezoneLookup = orig })
+
+	got, err := handlers.ParseLocalToUTC("2023-01-02T15:04", "XXX", "America/Los_Angeles")
+	if err != nil {
+		t.Fatalf("ParseLocalToUTC returned error: %v", err)
+	}
+
+	expected := time.Date(2023, time.January, 2, 23, 4, 0, 0, time.UTC)
+	if !got.Equal(expected) {
+		t.Errorf("expected %v, got %v", expected, got)
+	}
+}


### PR DESCRIPTION
## Summary
- expose ParseLocalToUTC so it can be exercised outside handlers
- relocate ParseLocalToUTC tests to a dedicated `testing` folder
- add `testing/README.md` with instructions on running the suite

## Testing
- `go test -count=1 ./...`


------
https://chatgpt.com/codex/tasks/task_e_68955ab18f40832cb6f978a1f1fb3e7a